### PR TITLE
fix(📏): Disable import checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,5 +43,7 @@ module.exports = {
     "react-native/no-inline-styles": 0,
     "react-native/no-color-literals": 2,
     "react-native/no-raw-text": 0,
+    "import/no-extraneous-dependencies": 0,
+    "import/no-unresolved": 0
   }
 };


### PR DESCRIPTION
We disable these rules because they don't seem to play well with the way expo provides expo for third parties libs.